### PR TITLE
feat: Add terra build dir to store the build cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  publish:
+  unit_test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,3 +23,27 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash tool/run_ut.sh
+
+  integration_test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://npm.pkg.github.com"
+          # Defaults to the user or organization that owns the workflow file
+          scope: "@agoraio-extensions"
+
+      - name: Run unit test
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export LLVM_DOWNLOAD_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+          
+          npm install
+          npm run test:integration

--- a/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
+++ b/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { TerraContext } from '@agoraio-extensions/terra-core';
+
+import { dumpCXXAstJson } from '../src/cxx_parser';
+
+describe('cxx_parser', () => {
+  let tmpDir: string = '';
+  let cppastBackendPath: string = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'terra-ut-'));
+    cppastBackendPath = path.join(__dirname, '..', 'cxx', 'cppast_backend');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('dumpCXXAstJson', () => {
+    it('generate ast json by default', () => {
+      let file1Path = path.join(tmpDir, 'file1.h');
+
+      fs.writeFileSync(
+        file1Path,
+        `
+struct AAA {
+    int a;
+}
+`
+      );
+
+      // TODO(littlegnal): Should move the tmp/*.h to the build dir in the future
+      const expectedJson = `
+      [
+        {
+          "__TYPE":"CXXFile",
+          "file_path":"${cppastBackendPath}/tmp/file1.h",
+          "nodes":[
+            {
+              "__TYPE":"Struct",
+              "attributes":[],
+              "base_clazzs":[],
+              "comment":"",
+              "constructors":[],
+              "file_path":"${cppastBackendPath}/tmp/file1.h",
+              "member_variables":[
+                {
+                  "__TYPE":"MemberVariable",
+                  "access_specifier":"",
+                  "is_mutable":false,
+                  "name":"a",
+                  "type":{
+                    "__TYPE":"SimpleType",
+                    "is_builtin_type":true,
+                    "is_const":false,
+                    "kind":100,
+                    "name":"int",
+                    "source":"int"
+                  }
+                }
+              ],
+              "methods":[],
+              "name":"AAA",
+              "namespaces":[],
+              "parent_name":"${cppastBackendPath}/tmp/file1.h",
+              "source":""
+            }
+          ]
+        }
+      ]
+      `;
+
+      let json = dumpCXXAstJson(
+        new TerraContext(tmpDir),
+        [],
+        [],
+        [file1Path],
+        []
+      );
+
+      // Use `JSON.parse` to parse the json string to avoid the format issue
+      expect(JSON.parse(json)).toEqual(JSON.parse(expectedJson));
+    });
+  });
+});

--- a/cxx-parser/__tests__/unit_test/cxx_parser.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser.test.ts
@@ -153,11 +153,10 @@ describe('cxx_parser', () => {
         `dump_json_${checkSum}.json`
       );
 
-      let isBuildDirExists = false;
+      let isBashCalled = false;
 
       (execSync as jest.Mock).mockImplementationOnce(() => {
-        // When passing the `TerraContext.clean` as true, the build dir should be removed.
-        isBuildDirExists = fs.existsSync(cppastBackendBuildDir);
+        isBashCalled = true;
 
         // Simulate generate the ast json file after run the bash script
         fs.mkdirSync(cppastBackendBuildDir, { recursive: true });
@@ -179,7 +178,7 @@ describe('cxx_parser', () => {
         stdio: 'inherit',
       });
       expect(json).toEqual(expectedJson);
-      expect(isBuildDirExists).toBe(false);
+      expect(isBashCalled).toBe(true);
     });
 
     it('generate ast json with cached ast json', () => {
@@ -233,7 +232,10 @@ describe('cxx_parser', () => {
       // Simulate cached ast json file exists
       fs.writeFileSync(jsonFilePath, expectedJson);
 
+      let isBashCalled = false;
+
       (execSync as jest.Mock).mockImplementationOnce(() => {
+        isBashCalled = true;
         return '';
       });
 
@@ -247,6 +249,7 @@ describe('cxx_parser', () => {
 
       expect(execSync).not.toHaveBeenCalled();
       expect(json).toEqual(expectedJson);
+      expect(isBashCalled).toBe(false);
     });
   });
 

--- a/cxx-parser/__tests__/unit_test/cxx_parser.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser.test.ts
@@ -12,26 +12,21 @@ jest.mock('child_process');
 describe('cxx_parser', () => {
   let tmpDir: string = '';
   let cppastBackendBuildDir: string = '';
+  let cppastBackendBuildBashPath: string = '';
 
   beforeEach(() => {
     (execSync as jest.Mock).mockReset();
 
-    // Since the test run on the root of the `cxx-parser`, so we can concat the path
-    // as relative path here.
-    cppastBackendBuildDir = path.join(
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'terra-ut-'));
+    cppastBackendBuildDir = path.join(tmpDir, 'cxx_parser');
+    cppastBackendBuildBashPath = path.join(
       __dirname,
       '..',
       '..',
       'cxx',
       'cppast_backend',
-      'build'
+      'build.sh'
     );
-    // Clean the build dir before each test case.
-    if (fs.existsSync(cppastBackendBuildDir)) {
-      fs.rmSync(cppastBackendBuildDir, { recursive: true, force: true });
-    }
-
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'terra-ut-'));
   });
 
   afterEach(() => {
@@ -95,18 +90,14 @@ describe('cxx_parser', () => {
       });
 
       let json = dumpCXXAstJson(
-        new TerraContext(),
+        new TerraContext(tmpDir),
         [],
         [],
         [file1Path, file2Path],
         []
       );
 
-      let cppastBackendBuildBashPath = path.join(
-        path.resolve(cppastBackendBuildDir, '..'),
-        'build.sh'
-      );
-      let expectedBashScript = `bash ${cppastBackendBuildBashPath} "--visit-headers=${file1Path},${file2Path} --include-header-dirs= --defines-macros="" --custom-headers= --output-dir=${jsonFilePath} --dump-json"`;
+      let expectedBashScript = `bash ${cppastBackendBuildBashPath} \"${cppastBackendBuildDir}\" "--visit-headers=${file1Path},${file2Path} --include-header-dirs= --defines-macros="" --custom-headers= --output-dir=${jsonFilePath} --dump-json"`;
       expect(execSync).toHaveBeenCalledWith(expectedBashScript, {
         encoding: 'utf8',
         stdio: 'inherit',
@@ -175,18 +166,14 @@ describe('cxx_parser', () => {
       });
 
       let json = dumpCXXAstJson(
-        new TerraContext('', '', true, false),
+        new TerraContext(tmpDir, '', '', true, false),
         [],
         [],
         [file1Path, file2Path],
         []
       );
 
-      let cppastBackendBuildBashPath = path.join(
-        path.resolve(cppastBackendBuildDir, '..'),
-        'build.sh'
-      );
-      let expectedBashScript = `bash ${cppastBackendBuildBashPath} "--visit-headers=${file1Path},${file2Path} --include-header-dirs= --defines-macros="" --custom-headers= --output-dir=${jsonFilePath} --dump-json"`;
+      let expectedBashScript = `bash ${cppastBackendBuildBashPath} \"${cppastBackendBuildDir}\" "--visit-headers=${file1Path},${file2Path} --include-header-dirs= --defines-macros="" --custom-headers= --output-dir=${jsonFilePath} --dump-json"`;
       expect(execSync).toHaveBeenCalledWith(expectedBashScript, {
         encoding: 'utf8',
         stdio: 'inherit',
@@ -251,7 +238,7 @@ describe('cxx_parser', () => {
       });
 
       let json = dumpCXXAstJson(
-        new TerraContext(),
+        new TerraContext(tmpDir),
         [],
         [],
         [file1Path, file2Path],

--- a/cxx-parser/cxx/cppast_backend/build.sh
+++ b/cxx-parser/cxx/cppast_backend/build.sh
@@ -5,8 +5,8 @@ set -x
 
 SCRIPT_PATH=$(dirname "$0")
 MY_PATH=$(realpath ${SCRIPT_PATH})
-OUTPUT_PATH=$MY_PATH/build
-ARGS=$1
+OUTPUT_PATH=$1
+ARGS=$2
 
 if [ ! -d "${OUTPUT_PATH}" ]; then
     mkdir -p ${OUTPUT_PATH}

--- a/cxx-parser/src/cxx_parser.ts
+++ b/cxx-parser/src/cxx_parser.ts
@@ -31,6 +31,9 @@ export function dumpCXXAstJson(
 ): string {
   let parseFilesChecksum = generateChecksum(parseFiles);
 
+  // <my_project>/.terra/cxx_parser
+  let buildDir = path.join(terraContext.buildDir, 'cxx_parser');
+
   let agora_rtc_ast_dir_path = path.join(
     __dirname,
     '..',
@@ -39,7 +42,7 @@ export function dumpCXXAstJson(
   );
 
   let build_shell_path = path.join(agora_rtc_ast_dir_path, 'build.sh');
-  let build_cache_dir_path = path.join(agora_rtc_ast_dir_path, 'build');
+  let build_cache_dir_path = buildDir;
   let outputJsonFileName = `dump_json_${parseFilesChecksum}.json`;
   let outputJsonPath = path.join(build_cache_dir_path, outputJsonFileName);
 
@@ -54,6 +57,11 @@ export function dumpCXXAstJson(
     );
     let ast_json_file_content = fs.readFileSync(outputJsonPath, 'utf-8');
     return ast_json_file_content;
+  }
+
+  // Ensure the build cache dir exists
+  if (!fs.existsSync(build_cache_dir_path)) {
+    fs.mkdirSync(build_cache_dir_path, { recursive: true });
   }
 
   let include_header_dirs_arg = includeHeaderDirs.join(',');
@@ -72,7 +80,7 @@ export function dumpCXXAstJson(
 
   bashArgs += ` --dump-json`;
 
-  let buildScript = `bash ${build_shell_path} \"${bashArgs}\"`;
+  let buildScript = `bash ${build_shell_path} \"${buildDir}\" \"${bashArgs}\"`;
   console.log(`Running command: \n${buildScript}`);
 
   execSync(buildScript, { encoding: 'utf8', stdio: 'inherit' });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,33 @@
 module.exports = {
   projects: [
     {
+      displayName: 'test',
+      coverageDirectory: 'test',
+      preset: 'ts-jest',
+      testEnvironment: 'node',
+      testRegex: './*/__tests__/.*\\.(test|spec)\\.[jt]sx?$',
+    },
+    {
+      displayName: 'integration',
+      coverageDirectory: 'integration',
+      preset: 'ts-jest',
+      testEnvironment: 'node',
+      testRegex: './*/__integration_test__/.*\\.integration\\.test\\.[jt]sx?$',
+    },
+    {
       displayName: 'cxx-parser',
       coverageDirectory: 'cxx-parser',
       preset: 'ts-jest',
       testEnvironment: 'node',
       testRegex: 'cxx-parser/__tests__/.*\\.(test|spec)\\.[jt]sx?$',
+    },
+    {
+      displayName: 'integration:cxx-parser',
+      coverageDirectory: 'integration:cxx-parser',
+      preset: 'ts-jest',
+      testEnvironment: 'node',
+      testRegex:
+        'cxx-parser/__integration_test__/.*\\.integration\\.test\\.[jt]sx?$',
     },
     {
       displayName: 'terra',

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "test": "jest --coverage",
+    "test": "jest --coverage --selectProjects=test",
+    "test:integration": "jest --coverage --selectProjects=integration",
     "test:terra": "jest --selectProjects=terra",
     "test:terra-core": "jest --selectProjects=terra-core",
     "test:cxx-parser": "jest --selectProjects=cxx-parser",
+    "test:integration:cxx-parser": "jest --selectProjects=integration:cxx-parser",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/terra-core/src/index.ts
+++ b/terra-core/src/index.ts
@@ -9,6 +9,7 @@ export class ParseResult {
 
 export class TerraContext {
   constructor(
+    public readonly buildDir: string = '',
     public readonly configDir: string = '',
     public readonly outputDir: string = '',
     public readonly clean: boolean = false,

--- a/terra-core/src/path_resolver.ts
+++ b/terra-core/src/path_resolver.ts
@@ -34,6 +34,7 @@ export function resolvePath(
   return path.resolve(localPathInModule);
 }
 
+// TODO(littlegnal): Use `require.resolve(`${module}/package.json`)` to require the module's path
 export function resolveModulePath(module: string): string {
   let currentPackageJsonPath = process.env.npm_package_json;
   let currentPackageNodeModuleDir = path.join(
@@ -48,6 +49,7 @@ export function resolveModulePath(module: string): string {
   return path.resolve(parserPackageDir);
 }
 
+// TODO(littlegnal): Use `require(`${module}/package.json`)` to require the module
 export function requireModule(module: string): any {
   let currentPackageJsonPath = process.env.npm_package_json;
   let currentPackageNodeModuleDir = path.join(

--- a/terra/__tests__/unit_test/renderers/dump_json_renderer.test.ts
+++ b/terra/__tests__/unit_test/renderers/dump_json_renderer.test.ts
@@ -18,7 +18,7 @@ describe('dumpJsonRenderer', () => {
     let tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'terra-ut-'));
 
     let dumpJsonFunc = dumpJsonRenderer(
-      new TerraContext('', tmpDir, false, false)
+      new TerraContext('', '', tmpDir, false, false)
     );
     let terraAstPath = path.join(tmpDir, terraAstJsonFileName);
 

--- a/terra/src/commands/run_command.ts
+++ b/terra/src/commands/run_command.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import path from 'path';
 
 import { TerraContext, resolvePath } from '@agoraio-extensions/terra-core';
@@ -25,9 +26,19 @@ export class RunCommand extends BaseRenderCommand {
 
     console.log(`Parsed TerraConfigs: \n${JSON.stringify(terraConfigs)}`);
 
+    let hostPackageJsonPath = process.env.npm_package_json;
+    // <my_project>/.terra
+    let buildDir = path.resolve(path.dirname(hostPackageJsonPath!), '.terra');
+    if (cliOption.clean && fs.existsSync(buildDir)) {
+      fs.rmSync(buildDir, { recursive: true, force: true });
+    }
+    if (!fs.existsSync(buildDir)) {
+      fs.mkdirSync(buildDir, { recursive: true });
+    }
+
     let defaultVisitor = new TerraShell();
     let loader = new TerraConfigLoader(cliOption);
-    // let parsersLoader = new ParsersLoader();
+
     if (terraConfigs.include) {
       let includeConfigs = TerraConfigs.parse(terraConfigs.include);
       let includeConfigDir = path.dirname(resolvePath(terraConfigs.include));
@@ -35,6 +46,7 @@ export class RunCommand extends BaseRenderCommand {
       loader
         .loadParsers(
           new TerraContext(
+            buildDir,
             includeConfigDir,
             cliOption.outputDir,
             cliOption.clean
@@ -49,6 +61,7 @@ export class RunCommand extends BaseRenderCommand {
     loader
       .loadParsers(
         new TerraContext(
+          buildDir,
           path.dirname(cliOption.config),
           cliOption.outputDir,
           cliOption.clean
@@ -63,6 +76,7 @@ export class RunCommand extends BaseRenderCommand {
       defaultVisitor.addRenderer(
         dumpJsonRenderer(
           new TerraContext(
+            buildDir,
             path.dirname(cliOption.config),
             cliOption.outputDir,
             cliOption.clean
@@ -73,6 +87,7 @@ export class RunCommand extends BaseRenderCommand {
       loader
         .loadRenderers(
           new TerraContext(
+            buildDir,
             path.dirname(cliOption.config),
             cliOption.outputDir,
             cliOption.clean


### PR DESCRIPTION
Add build dir `<my_project>/.terra`

So parsers and renderers have a place to store their cache.