### PR TITLE
fix: [cxx-parser] Fix files order when call CXXParserConfigs.resolve

### DIFF
--- a/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
@@ -33,7 +33,9 @@ describe('CXXParserConfigs', () => {
       args as unknown as CXXParserConfigs
     );
 
-    let expectedFiles = fs.readdirSync(tmpDir);
+    let expectedFiles = fs.readdirSync(tmpDir).map((it) => {
+      return path.join(tmpDir, it);
+    });
 
     expect(config.parseFiles.include.length).toBe(2);
     expect(config.parseFiles.include[0]).toEqual(expectedFiles[0]); // file1.h

--- a/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { CXXParserConfigs } from '../../src/cxx_parser_configs';
+
+describe('CXXParserConfigs', () => {
+  let tmpDir: string = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'terra-ut-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolve parseFiles and keep path order', () => {
+    let path1 = path.join(tmpDir, 'file1.h');
+    let path2 = path.join(tmpDir, 'file2.h');
+    fs.writeFileSync(path1, '// file1.h');
+    fs.writeFileSync(path2, '// file2.h');
+
+    let args = {
+      includeHeaderDirs: [],
+      definesMacros: [],
+      parseFiles: { include: [path1, path2] },
+      customHeaders: [],
+    };
+
+    let config = CXXParserConfigs.resolve(
+      tmpDir,
+      args as unknown as CXXParserConfigs
+    );
+
+    let expectedFiles = fs.readdirSync(tmpDir);
+
+    expect(config.parseFiles.include).toEqual(expectedFiles);
+  });
+});

--- a/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
@@ -35,6 +35,8 @@ describe('CXXParserConfigs', () => {
 
     let expectedFiles = fs.readdirSync(tmpDir);
 
-    expect(config.parseFiles.include).toEqual(expectedFiles);
+    expect(config.parseFiles.include.length).toBe(2);
+    expect(config.parseFiles.include[0]).toEqual(expectedFiles[0]); // file1.h
+    expect(config.parseFiles.include[1]).toEqual(expectedFiles[1]); // file2.h
   });
 });

--- a/cxx-parser/package.json
+++ b/cxx-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoraio-extensions/cxx-parser",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "src/index",
   "author": "",
   "license": "ISC",

--- a/cxx-parser/src/cxx_parser_configs.ts
+++ b/cxx-parser/src/cxx_parser_configs.ts
@@ -1,12 +1,9 @@
 import { resolvePath } from '@agoraio-extensions/terra-core';
 import { globSync } from 'glob';
 
-function _resolvePaths(globPaths: string[]): string[] {
-  let res: string[] = [];
-  globPaths.forEach((it) => {
-    res.push(...globSync(it));
-  });
-  return res;
+function _resolvePaths(globPath: string, configDir: string): string[] {
+  // The files order will descend when using globSync. So we sort the files to ensure the order.
+  return globSync(resolvePath(globPath, configDir)).sort();
 }
 
 export interface ParseFilesConfig {
@@ -26,25 +23,25 @@ export class CXXParserConfigs {
     return {
       includeHeaderDirs: (original.includeHeaderDirs ?? [])
         .map((it) => {
-          return globSync(resolvePath(it, configDir));
+          return _resolvePaths(it, configDir);
         })
         .flat(1),
       definesMacros: original.definesMacros ?? [],
       parseFiles: {
         include: (original.parseFiles.include ?? [])
           .map((it) => {
-            return globSync(resolvePath(it, configDir));
+            return _resolvePaths(it, configDir);
           })
           .flat(1),
         exclude: (original.parseFiles.exclude ?? [])
           .map((it) => {
-            return globSync(resolvePath(it, configDir));
+            return _resolvePaths(it, configDir);
           })
           .flat(1),
       },
       customHeaders: (original.customHeaders ?? [])
         .map((it) => {
-          return globSync(resolvePath(it, configDir));
+          return _resolvePaths(it, configDir);
         })
         .flat(1),
     };


### PR DESCRIPTION
The file order will descend when using `globSync`. So we sorted the files to ensure the order.