### PR TITLE
feat: [cxx-parser] ParseResult.resolveNodeByType extension

### DIFF
--- a/cxx-parser/__tests__/unit_test/cxx_parser_ext.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser_ext.test.ts
@@ -1,0 +1,166 @@
+import '../../src/cxx_parser_ext';
+import { ParseResult } from '@agoraio-extensions/terra-core';
+
+import {
+  Clazz,
+  Enumz,
+  SimpleType,
+  SimpleTypeKind,
+  Struct,
+} from '../../src/cxx_terra_node';
+
+describe('ParseResult', () => {
+  describe('resolveNodeByType', () => {
+    it('can find Clazz when the SimpleType ref to a class', () => {
+      let parseResult = new ParseResult();
+      const simpleType = new SimpleType();
+      simpleType.kind = SimpleTypeKind.pointer_t;
+      simpleType.name = 'A::B::MyClass';
+      simpleType.source = 'MyClass*';
+
+      const clazz = new Clazz();
+      clazz.name = 'MyClass';
+      clazz.namespaces = ['A', 'B'];
+
+      parseResult.nodes = [
+        {
+          nodes: [clazz],
+        },
+      ];
+
+      const node = parseResult.resolveNodeByType(simpleType);
+      expect(node).toBe(clazz);
+    });
+
+    it('can find Struct when the SimpleType ref to a struct', () => {
+      let parseResult = new ParseResult();
+      const simpleType = new SimpleType();
+      simpleType.kind = SimpleTypeKind.pointer_t;
+      simpleType.name = 'A::B::MyStruct';
+      simpleType.source = 'MyStruct*';
+
+      const struct = new Struct();
+      struct.name = 'MyStruct';
+      struct.namespaces = ['A', 'B'];
+
+      parseResult.nodes = [
+        {
+          nodes: [struct],
+        },
+      ];
+
+      const node = parseResult.resolveNodeByType(simpleType);
+      expect(node).toBe(struct);
+    });
+
+    it('can find Enum, when the SimpleType ref to a enum', () => {
+      let parseResult = new ParseResult();
+      const simpleType = new SimpleType();
+      simpleType.kind = SimpleTypeKind.pointer_t;
+      simpleType.name = 'A::B::MyEnum';
+      simpleType.source = 'MyEnum*';
+
+      const enumz = new Enumz();
+      enumz.name = 'MyEnum';
+      enumz.namespaces = ['A', 'B'];
+
+      parseResult.nodes = [
+        {
+          nodes: [enumz],
+        },
+      ];
+
+      const node = parseResult.resolveNodeByType(simpleType);
+      expect(node).toBe(enumz);
+    });
+
+    it('return type if it is built-in type', () => {
+      let parseResult = new ParseResult();
+      const simpleType = new SimpleType();
+      simpleType.kind = SimpleTypeKind.value_t;
+      simpleType.name = 'int';
+      simpleType.source = 'int';
+
+      const returnType = parseResult.resolveNodeByType(simpleType);
+      expect(returnType).toBe(simpleType);
+    });
+
+    it('can find Clazz when the SimpleType is template_t and template_arguments ref to a class', () => {
+      let parseResult = new ParseResult();
+      const simpleType = new SimpleType();
+      simpleType.kind = SimpleTypeKind.template_t;
+      simpleType.name = 'TemplateType';
+      simpleType.source = 'TemplateType<MyClass>';
+      simpleType.template_arguments = ['A::B::MyClass'];
+
+      const clazz = new Clazz();
+      clazz.name = 'MyClass';
+      clazz.namespaces = ['A', 'B'];
+
+      parseResult.nodes = [
+        {
+          nodes: [clazz],
+        },
+      ];
+
+      const node = parseResult.resolveNodeByType(simpleType);
+      expect(node).toBe(clazz);
+    });
+
+    it('can find Struct when the SimpleType is template_t and template_arguments ref to a struct', () => {
+      let parseResult = new ParseResult();
+      const simpleType = new SimpleType();
+      simpleType.kind = SimpleTypeKind.template_t;
+      simpleType.name = 'TemplateType';
+      simpleType.source = 'TemplateType<MyStruct>';
+      simpleType.template_arguments = ['A::B::MyStruct'];
+
+      const struct = new Struct();
+      struct.name = 'MyStruct';
+      struct.namespaces = ['A', 'B'];
+
+      parseResult.nodes = [
+        {
+          nodes: [struct],
+        },
+      ];
+
+      const node = parseResult.resolveNodeByType(simpleType);
+      expect(node).toBe(struct);
+    });
+
+    it('can find Enum, when the SimpleType is template_t and template_arguments ref to a enum', () => {
+      let parseResult = new ParseResult();
+      const simpleType = new SimpleType();
+      simpleType.kind = SimpleTypeKind.template_t;
+      simpleType.name = 'TemplateType';
+      simpleType.source = 'TemplateType<MyEnum>';
+      simpleType.template_arguments = ['A::B::MyEnum'];
+
+      const enumz = new Enumz();
+      enumz.name = 'MyEnum';
+      enumz.namespaces = ['A', 'B'];
+
+      parseResult.nodes = [
+        {
+          nodes: [enumz],
+        },
+      ];
+
+      const node = parseResult.resolveNodeByType(simpleType);
+      expect(node).toBe(enumz);
+    });
+
+    it('return type if the SimpleType is template_t and template_arguments not ref to any nodes', () => {
+      let parseResult = new ParseResult();
+      const simpleType = new SimpleType();
+      simpleType.kind = SimpleTypeKind.template_t;
+      simpleType.name = 'TemplateType';
+      simpleType.source = 'TemplateType<int>';
+      simpleType.template_arguments = ['int'];
+
+      const returnType = parseResult.resolveNodeByType(simpleType);
+      expect(returnType).toBe(simpleType);
+    });
+  });
+});

--- a/cxx-parser/src/cxx_terra_node_ext.ts
+++ b/cxx-parser/src/cxx_terra_node_ext.ts
@@ -4,23 +4,6 @@ import { SimpleType, SimpleTypeKind } from './cxx_terra_node';
 
 export {};
 
-declare global {
-  export interface String {
-    /**
-     * This function removes the namespace from a fully qualified name.
-     * For example, "foo::bar" becomes "bar".
-     */
-    trimNamespace(): string;
-
-    /**
-     * Returns the namespace of the class name.
-     *
-     * Example: "std::vector::size_type" returns "std::vector"
-     */
-    getNamespace(): string;
-  }
-}
-
 declare module '@agoraio-extensions/cxx-parser' {
   export interface SimpleType {
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2021",
     "module": "commonjs",
     "strict": true,
     "sourceMap": true,


### PR DESCRIPTION
Add `ParseResult.resolveNodeByType` extension function to simplify the find node operation by `SimpleType`