### PR TITLE
fix: Fix can not parse typedef correctly if there are struct/enum/class node before the typedef declaration

### DIFF
--- a/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
+++ b/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
@@ -264,7 +264,6 @@ describe('cxx_parser', () => {
               {
                 "__TYPE":"Enumz",
                 "attributes":[],
-                "base_clazzs":[],
                 "comment":"",
                 "enum_constants": [
                   {
@@ -326,7 +325,6 @@ describe('cxx_parser', () => {
               {
                 "__TYPE":"Enumz",
                 "attributes":[],
-                "base_clazzs":[],
                 "comment":"",
                 "enum_constants": [
                   {
@@ -383,6 +381,100 @@ describe('cxx_parser', () => {
             "__TYPE":"CXXFile",
             "file_path":"${preProcessParseFilesDir}/file1.h",
             "nodes":[
+              {
+                "__TYPE": "TypeAlias",
+                "attributes": [],
+                "comment": "",
+                "file_path":"${preProcessParseFilesDir}/file1.h",
+                "name": "view_t",
+                "namespaces": [],
+                "parent_name":"${preProcessParseFilesDir}/file1.h",
+                "source": "",
+                "underlyingType": {
+                  "__TYPE": "SimpleType",
+                  "is_builtin_type": true,
+                  "is_const": false,
+                  "kind": 101,
+                  "name": "void",
+                  "source": "void*",
+                  "template_arguments": []
+                }
+              }
+            ]
+          }
+        ]
+        `;
+
+        let json = dumpCXXAstJson(
+          new TerraContext(tmpDir),
+          [],
+          [file1Path],
+          []
+        );
+
+        expect(fs.existsSync(preProcessParseFilesDir)).toBe(true);
+
+        // Use `JSON.parse` to parse the json string to avoid the format issue
+        expect(JSON.parse(json)).toEqual(JSON.parse(expectedJson));
+      });
+
+      it('normal typedef void* under typedef struct', () => {
+        let file1Path = path.join(tmpDir, 'file1.h');
+
+        fs.writeFileSync(
+          file1Path,
+          `
+  struct AAA {
+    int a;
+  };
+
+  typedef void* view_t;
+  `
+        );
+
+        let checkSum = generateChecksum([file1Path]);
+        let preProcessParseFilesDir = path.join(
+          cxxParserCacheDir,
+          `preProcess@${checkSum}`
+        );
+
+        // TODO(littlegnal): Should move the tmp/*.h to the build dir in the future
+        const expectedJson = `
+        [
+          {
+            "__TYPE":"CXXFile",
+            "file_path":"${preProcessParseFilesDir}/file1.h",
+            "nodes":[
+              {
+                "__TYPE":"Struct",
+                "attributes":[],
+                "base_clazzs":[],
+                "comment":"",
+                "constructors":[],
+                "file_path":"${preProcessParseFilesDir}/file1.h",
+                "member_variables":[
+                  {
+                    "__TYPE":"MemberVariable",
+                    "access_specifier":"",
+                    "is_mutable":false,
+                    "name":"a",
+                    "type":{
+                      "__TYPE":"SimpleType",
+                      "is_builtin_type":true,
+                      "is_const":false,
+                      "kind":100,
+                      "name":"int",
+                      "source":"int",
+                      "template_arguments":[]
+                    }
+                  }
+                ],
+                "methods":[],
+                "name":"AAA",
+                "namespaces":[],
+                "parent_name":"${preProcessParseFilesDir}/file1.h",
+                "source":""
+              },
               {
                 "__TYPE": "TypeAlias",
                 "attributes": [],

--- a/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
+++ b/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
@@ -88,6 +88,288 @@ struct AAA {
       // Use `JSON.parse` to parse the json string to avoid the format issue
       expect(JSON.parse(json)).toEqual(JSON.parse(expectedJson));
     });
+
+    describe('parse typedef', () => {
+      it('c-style typedef struct', () => {
+        let file1Path = path.join(tmpDir, 'file1.h');
+
+        fs.writeFileSync(
+          file1Path,
+          `
+  typedef struct AAA {
+  } AAA;
+  `
+        );
+
+        let checkSum = generateChecksum([file1Path]);
+        let preProcessParseFilesDir = path.join(
+          cxxParserCacheDir,
+          `preProcess@${checkSum}`
+        );
+
+        // TODO(littlegnal): Should move the tmp/*.h to the build dir in the future
+        const expectedJson = `
+        [
+          {
+            "__TYPE":"CXXFile",
+            "file_path":"${preProcessParseFilesDir}/file1.h",
+            "nodes":[
+              {
+                "__TYPE":"Struct",
+                "attributes":[],
+                "base_clazzs":[],
+                "comment":"",
+                "constructors":[],
+                "file_path":"${preProcessParseFilesDir}/file1.h",
+                "member_variables":[],
+                "methods":[],
+                "name":"AAA",
+                "namespaces":[],
+                "parent_name":"${preProcessParseFilesDir}/file1.h",
+                "source":""
+              }
+            ]
+          }
+        ]
+        `;
+
+        let json = dumpCXXAstJson(
+          new TerraContext(tmpDir),
+          [],
+          [file1Path],
+          []
+        );
+
+        expect(fs.existsSync(preProcessParseFilesDir)).toBe(true);
+
+        // Use `JSON.parse` to parse the json string to avoid the format issue
+        expect(JSON.parse(json)).toEqual(JSON.parse(expectedJson));
+      });
+
+      it('c-style typedef struct with empty name', () => {
+        let file1Path = path.join(tmpDir, 'file1.h');
+
+        fs.writeFileSync(
+          file1Path,
+          `
+  typedef struct {
+  } AAA;
+  `
+        );
+
+        let checkSum = generateChecksum([file1Path]);
+        let preProcessParseFilesDir = path.join(
+          cxxParserCacheDir,
+          `preProcess@${checkSum}`
+        );
+
+        // TODO(littlegnal): Should move the tmp/*.h to the build dir in the future
+        const expectedJson = `
+        [
+          {
+            "__TYPE":"CXXFile",
+            "file_path":"${preProcessParseFilesDir}/file1.h",
+            "nodes":[
+              {
+                "__TYPE":"Struct",
+                "attributes":[],
+                "base_clazzs":[],
+                "comment":"",
+                "constructors":[],
+                "file_path":"${preProcessParseFilesDir}/file1.h",
+                "member_variables":[],
+                "methods":[],
+                "name":"AAA",
+                "namespaces":[],
+                "parent_name":"${preProcessParseFilesDir}/file1.h",
+                "source":""
+              }
+            ]
+          }
+        ]
+        `;
+
+        let json = dumpCXXAstJson(
+          new TerraContext(tmpDir),
+          [],
+          [file1Path],
+          []
+        );
+
+        expect(fs.existsSync(preProcessParseFilesDir)).toBe(true);
+
+        // Use `JSON.parse` to parse the json string to avoid the format issue
+        expect(JSON.parse(json)).toEqual(JSON.parse(expectedJson));
+      });
+
+      it('c-style typedef enum', () => {
+        let file1Path = path.join(tmpDir, 'file1.h');
+
+        fs.writeFileSync(
+          file1Path,
+          `
+  typedef enum MyEnum {
+  } MyEnum;
+  `
+        );
+
+        let checkSum = generateChecksum([file1Path]);
+        let preProcessParseFilesDir = path.join(
+          cxxParserCacheDir,
+          `preProcess@${checkSum}`
+        );
+
+        // TODO(littlegnal): Should move the tmp/*.h to the build dir in the future
+        const expectedJson = `
+        [
+          {
+            "__TYPE":"CXXFile",
+            "file_path":"${preProcessParseFilesDir}/file1.h",
+            "nodes":[
+              {
+                "__TYPE":"Enumz",
+                "attributes":[],
+                "base_clazzs":[],
+                "comment":"",
+                "enum_constants":[],
+                "file_path":"${preProcessParseFilesDir}/file1.h",
+                "name":"MyEnum",
+                "namespaces":[],
+                "parent_name":"${preProcessParseFilesDir}/file1.h",
+                "source":""
+              }
+            ]
+          }
+        ]
+        `;
+
+        let json = dumpCXXAstJson(
+          new TerraContext(tmpDir),
+          [],
+          [file1Path],
+          []
+        );
+
+        expect(fs.existsSync(preProcessParseFilesDir)).toBe(true);
+
+        // Use `JSON.parse` to parse the json string to avoid the format issue
+        expect(JSON.parse(json)).toEqual(JSON.parse(expectedJson));
+      });
+
+      it('c-style typedef enum with empty name', () => {
+        let file1Path = path.join(tmpDir, 'file1.h');
+
+        fs.writeFileSync(
+          file1Path,
+          `
+  typedef enum {
+  } MyEnum;
+  `
+        );
+
+        let checkSum = generateChecksum([file1Path]);
+        let preProcessParseFilesDir = path.join(
+          cxxParserCacheDir,
+          `preProcess@${checkSum}`
+        );
+
+        // TODO(littlegnal): Should move the tmp/*.h to the build dir in the future
+        const expectedJson = `
+        [
+          {
+            "__TYPE":"CXXFile",
+            "file_path":"${preProcessParseFilesDir}/file1.h",
+            "nodes":[
+              {
+                "__TYPE":"Enumz",
+                "attributes":[],
+                "base_clazzs":[],
+                "comment":"",
+                "enum_constants":[],
+                "file_path":"${preProcessParseFilesDir}/file1.h",
+                "name":"MyEnum",
+                "namespaces":[],
+                "parent_name":"${preProcessParseFilesDir}/file1.h",
+                "source":""
+              }
+            ]
+          }
+        ]
+        `;
+
+        let json = dumpCXXAstJson(
+          new TerraContext(tmpDir),
+          [],
+          [file1Path],
+          []
+        );
+
+        expect(fs.existsSync(preProcessParseFilesDir)).toBe(true);
+
+        // Use `JSON.parse` to parse the json string to avoid the format issue
+        expect(JSON.parse(json)).toEqual(JSON.parse(expectedJson));
+      });
+
+      it('normal typedef void*', () => {
+        let file1Path = path.join(tmpDir, 'file1.h');
+
+        fs.writeFileSync(
+          file1Path,
+          `
+  typedef void* view_t;
+  `
+        );
+
+        let checkSum = generateChecksum([file1Path]);
+        let preProcessParseFilesDir = path.join(
+          cxxParserCacheDir,
+          `preProcess@${checkSum}`
+        );
+
+        // TODO(littlegnal): Should move the tmp/*.h to the build dir in the future
+        const expectedJson = `
+        [
+          {
+            "__TYPE":"CXXFile",
+            "file_path":"${preProcessParseFilesDir}/file1.h",
+            "nodes":[
+              {
+                "__TYPE": "TypeAlias",
+                "attributes": [],
+                "comment": "",
+                "file_path":"${preProcessParseFilesDir}/file1.h",
+                "name": "view_t",
+                "namespaces": [],
+                "parent_name":"${preProcessParseFilesDir}/file1.h",
+                "source": "",
+                "underlyingType": {
+                  "__TYPE": "SimpleType",
+                  "is_builtin_type": true,
+                  "is_const": false,
+                  "kind": 101,
+                  "name": "void",
+                  "source": "void*",
+                  "template_arguments": []
+                }
+              }
+            ]
+          }
+        ]
+        `;
+
+        let json = dumpCXXAstJson(
+          new TerraContext(tmpDir),
+          [],
+          [file1Path],
+          []
+        );
+
+        expect(fs.existsSync(preProcessParseFilesDir)).toBe(true);
+
+        // Use `JSON.parse` to parse the json string to avoid the format issue
+        expect(JSON.parse(json)).toEqual(JSON.parse(expectedJson));
+      });
+    });
   });
 
   describe('CXXParser', () => {

--- a/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
+++ b/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
@@ -27,10 +27,10 @@ describe('cxx_parser', () => {
       fs.writeFileSync(
         file1Path,
         `
-struct AAA {
-  int a;
-};
-`
+    struct AAA {
+      int a;
+    };
+    `
       );
 
       let checkSum = generateChecksum([file1Path]);
@@ -41,45 +41,45 @@ struct AAA {
 
       // TODO(littlegnal): Should move the tmp/*.h to the build dir in the future
       const expectedJson = `
-      [
-        {
-          "__TYPE":"CXXFile",
-          "file_path":"${preProcessParseFilesDir}/file1.h",
-          "nodes":[
+          [
             {
-              "__TYPE":"Struct",
-              "attributes":[],
-              "base_clazzs":[],
-              "comment":"",
-              "constructors":[],
+              "__TYPE":"CXXFile",
               "file_path":"${preProcessParseFilesDir}/file1.h",
-              "member_variables":[
+              "nodes":[
                 {
-                  "__TYPE":"MemberVariable",
-                  "access_specifier":"",
-                  "is_mutable":false,
-                  "name":"a",
-                  "type":{
-                    "__TYPE":"SimpleType",
-                    "is_builtin_type":true,
-                    "is_const":false,
-                    "kind":100,
-                    "name":"int",
-                    "source":"int",
-                    "template_arguments":[]
-                  }
+                  "__TYPE":"Struct",
+                  "attributes":[],
+                  "base_clazzs":[],
+                  "comment":"",
+                  "constructors":[],
+                  "file_path":"${preProcessParseFilesDir}/file1.h",
+                  "member_variables":[
+                    {
+                      "__TYPE":"MemberVariable",
+                      "access_specifier":"",
+                      "is_mutable":false,
+                      "name":"a",
+                      "type":{
+                        "__TYPE":"SimpleType",
+                        "is_builtin_type":true,
+                        "is_const":false,
+                        "kind":100,
+                        "name":"int",
+                        "source":"int",
+                        "template_arguments":[]
+                      }
+                    }
+                  ],
+                  "methods":[],
+                  "name":"AAA",
+                  "namespaces":[],
+                  "parent_name":"${preProcessParseFilesDir}/file1.h",
+                  "source":""
                 }
-              ],
-              "methods":[],
-              "name":"AAA",
-              "namespaces":[],
-              "parent_name":"${preProcessParseFilesDir}/file1.h",
-              "source":""
+              ]
             }
           ]
-        }
-      ]
-      `;
+          `;
 
       let json = dumpCXXAstJson(new TerraContext(tmpDir), [], [file1Path], []);
 
@@ -97,6 +97,7 @@ struct AAA {
           file1Path,
           `
   typedef struct AAA {
+    int a;
   } AAA;
   `
         );
@@ -121,7 +122,23 @@ struct AAA {
                 "comment":"",
                 "constructors":[],
                 "file_path":"${preProcessParseFilesDir}/file1.h",
-                "member_variables":[],
+                "member_variables":[
+                  {
+                    "__TYPE":"MemberVariable",
+                    "access_specifier":"",
+                    "is_mutable":false,
+                    "name":"a",
+                    "type":{
+                      "__TYPE":"SimpleType",
+                      "is_builtin_type":true,
+                      "is_const":false,
+                      "kind":100,
+                      "name":"int",
+                      "source":"int",
+                      "template_arguments":[]
+                    }
+                  }
+                ],
                 "methods":[],
                 "name":"AAA",
                 "namespaces":[],
@@ -153,6 +170,7 @@ struct AAA {
           file1Path,
           `
   typedef struct {
+    int a;
   } AAA;
   `
         );
@@ -177,7 +195,23 @@ struct AAA {
                 "comment":"",
                 "constructors":[],
                 "file_path":"${preProcessParseFilesDir}/file1.h",
-                "member_variables":[],
+                "member_variables":[
+                  {
+                    "__TYPE":"MemberVariable",
+                    "access_specifier":"",
+                    "is_mutable":false,
+                    "name":"a",
+                    "type":{
+                      "__TYPE":"SimpleType",
+                      "is_builtin_type":true,
+                      "is_const":false,
+                      "kind":100,
+                      "name":"int",
+                      "source":"int",
+                      "template_arguments":[]
+                    }
+                  }
+                ],
                 "methods":[],
                 "name":"AAA",
                 "namespaces":[],
@@ -209,6 +243,7 @@ struct AAA {
           file1Path,
           `
   typedef enum MyEnum {
+    A = 0,
   } MyEnum;
   `
         );
@@ -231,7 +266,14 @@ struct AAA {
                 "attributes":[],
                 "base_clazzs":[],
                 "comment":"",
-                "enum_constants":[],
+                "enum_constants": [
+                  {
+                    "__TYPE": "EnumConstant",
+                    "name": "A",
+                    "source": "0",
+                    "value": "0"
+                  }
+                ],
                 "file_path":"${preProcessParseFilesDir}/file1.h",
                 "name":"MyEnum",
                 "namespaces":[],
@@ -263,6 +305,7 @@ struct AAA {
           file1Path,
           `
   typedef enum {
+    A = 0,
   } MyEnum;
   `
         );
@@ -285,7 +328,14 @@ struct AAA {
                 "attributes":[],
                 "base_clazzs":[],
                 "comment":"",
-                "enum_constants":[],
+                "enum_constants": [
+                  {
+                    "__TYPE": "EnumConstant",
+                    "name": "A",
+                    "source": "0",
+                    "value": "0"
+                  }
+                ],
                 "file_path":"${preProcessParseFilesDir}/file1.h",
                 "name":"MyEnum",
                 "namespaces":[],

--- a/cxx-parser/cxx/terra/include/terra.hpp
+++ b/cxx-parser/cxx/terra/include/terra.hpp
@@ -623,6 +623,8 @@ namespace terra
                             std::cout << "[type_alias_t] type name: " << cpp_type_alias.name() << ", under type: " << cppast::to_string(cpp_type_alias.underlying_type())
                                       << std::endl;
                         }
+
+                        return true;
                     }
 
                     if (e.kind() == cppast::cpp_entity_kind::class_t && !info.is_old_entity())

--- a/cxx-parser/cxx/terra/include/terra.hpp
+++ b/cxx-parser/cxx/terra/include/terra.hpp
@@ -111,8 +111,7 @@ namespace terra
                 auto &cpp_pointer_type = static_cast<const cppast::cpp_pointer_type &>(cpp_type);
                 to_simple_type(type, cpp_pointer_type.pointee(), true);
                 type.kind = SimpleTypeKind::pointer_t;
-                std::cout << "pointer_t: "
-                          << "\n";
+
                 break;
             }
             case cppast::cpp_type_kind::reference_t:
@@ -338,7 +337,6 @@ namespace terra
             parse_base_node(type_alias, namespaceList, file_path, cpp_type_alias);
 
             SimpleType st;
-            std::cout << "parse_type_alias: " << type_alias.name << "\n";
             to_simple_type(st, cpp_type_alias.underlying_type());
             type_alias.underlyingType = st;
 

--- a/cxx-parser/cxx/terra/include/terra.hpp
+++ b/cxx-parser/cxx/terra/include/terra.hpp
@@ -107,7 +107,6 @@ namespace terra
             }
             case cppast::cpp_type_kind::pointer_t:
             {
-
                 auto &cpp_pointer_type = static_cast<const cppast::cpp_pointer_type &>(cpp_type);
                 to_simple_type(type, cpp_pointer_type.pointee(), true);
                 type.kind = SimpleTypeKind::pointer_t;


### PR DESCRIPTION
Based on the current implementation of the logic of the type alias, the code below can not be handled
```c++
enum AUDIO_SESSION_OPERATION_RESTRICTION {

  AUDIO_SESSION_OPERATION_RESTRICTION_NONE = 0,
};

typedef const char* user_id_t;
typedef void* view_t;
```