### PR TITLE
feat: Add ParseFilesConfig.resolveParseFiles to handle the include/exclude config

### DIFF
--- a/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
@@ -42,3 +42,39 @@ describe('CXXParserConfigs', () => {
     expect(config.parseFiles.include[1]).toEqual(expectedFiles[1]); // file2.h
   });
 });
+
+describe('ParseFilesConfig', () => {
+  let tmpDir: string = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'terra-ut-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolveParseFiles with exclude', () => {
+    let path1 = path.join(tmpDir, 'file1.h');
+    let path2 = path.join(tmpDir, 'file2.h');
+    fs.writeFileSync(path1, '// file1.h');
+    fs.writeFileSync(path2, '// file2.h');
+
+    let args = {
+      includeHeaderDirs: [],
+      definesMacros: [],
+      parseFiles: { include: [path1, path2], exclude: [path2] },
+      customHeaders: [],
+    };
+
+    let config = CXXParserConfigs.resolve(
+      tmpDir,
+      args as unknown as CXXParserConfigs
+    );
+
+    let finalParseFiles = config.parseFiles.resolveParseFiles();
+
+    expect(finalParseFiles.length).toBe(1);
+    expect(finalParseFiles[0]).toEqual(path1); // file1.h
+  });
+});

--- a/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
@@ -2,7 +2,10 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { CXXParserConfigs } from '../../src/cxx_parser_configs';
+import {
+  CXXParserConfigs,
+  ParseFilesConfig,
+} from '../../src/cxx_parser_configs';
 
 describe('CXXParserConfigs', () => {
   let tmpDir: string = '';
@@ -72,7 +75,7 @@ describe('ParseFilesConfig', () => {
       args as unknown as CXXParserConfigs
     );
 
-    let finalParseFiles = config.parseFiles.resolveParseFiles();
+    let finalParseFiles = ParseFilesConfig.resolveParseFiles(config.parseFiles);
 
     expect(finalParseFiles.length).toBe(1);
     expect(finalParseFiles[0]).toEqual(path1); // file1.h

--- a/cxx-parser/src/cxx_parser.ts
+++ b/cxx-parser/src/cxx_parser.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import { ParseResult, TerraContext } from '@agoraio-extensions/terra-core';
 
 import { ClangASTStructConstructorParser } from './constructor_initializer_parser';
-import { CXXParserConfigs } from './cxx_parser_configs';
+import { CXXParserConfigs, ParseFilesConfig } from './cxx_parser_configs';
 import { CXXFile, CXXTYPE, cast } from './cxx_terra_node';
 
 export function generateChecksum(files: string[]) {
@@ -117,7 +117,9 @@ export function CXXParser(
 ): ParseResult | undefined {
   let cxxParserConfigs = CXXParserConfigs.resolve(terraContext.configDir, args);
 
-  let parseFiles = cxxParserConfigs.parseFiles.resolveParseFiles();
+  let parseFiles = ParseFilesConfig.resolveParseFiles(
+    cxxParserConfigs.parseFiles
+  );
   let jsonContent = dumpCXXAstJson(
     terraContext,
     cxxParserConfigs.includeHeaderDirs,

--- a/cxx-parser/src/cxx_parser.ts
+++ b/cxx-parser/src/cxx_parser.ts
@@ -117,9 +117,7 @@ export function CXXParser(
 ): ParseResult | undefined {
   let cxxParserConfigs = CXXParserConfigs.resolve(terraContext.configDir, args);
 
-  let parseFiles = cxxParserConfigs.parseFiles.include.filter((it) => {
-    return !cxxParserConfigs.parseFiles.exclude.includes(it);
-  });
+  let parseFiles = cxxParserConfigs.parseFiles.resolveParseFiles();
   let jsonContent = dumpCXXAstJson(
     terraContext,
     cxxParserConfigs.includeHeaderDirs,

--- a/cxx-parser/src/cxx_parser_configs.ts
+++ b/cxx-parser/src/cxx_parser_configs.ts
@@ -11,6 +11,27 @@ export interface ParseFilesConfig {
   exclude: string[];
 }
 
+export class ParseFilesConfig {
+  /**
+   * Resolves the files to be parsed based on the include and exclude configurations.
+   *
+   * The include and exclude configurations determine which files should be included or excluded from parsing.
+   *
+   * The logic for resolving the parse files is as follows:
+   * - If include is specified, only files matching the include patterns will be included.
+   * - If exclude is specified, files matching the exclude patterns will be excluded.
+   * - If both include and exclude are specified, files matching the include patterns but not matching the exclude patterns will be included.
+   * - If neither include nor exclude is specified, all files will be included.
+   *
+   * @returns An array of strings representing the files to be parsed.
+   */
+  resolveParseFiles(): string[] {
+    return this.include.filter((it) => {
+      return !this.exclude.includes(it);
+    });
+  }
+}
+
 export interface CXXParserConfigs {
   includeHeaderDirs: string[];
   definesMacros: string[];
@@ -37,7 +58,7 @@ export class CXXParserConfigs {
             return _resolvePaths(it, configDir);
           })
           .flat(1),
-      },
+      } as ParseFilesConfig,
     };
   }
 }

--- a/cxx-parser/src/cxx_parser_configs.ts
+++ b/cxx-parser/src/cxx_parser_configs.ts
@@ -25,9 +25,9 @@ export class ParseFilesConfig {
    *
    * @returns An array of strings representing the files to be parsed.
    */
-  resolveParseFiles(): string[] {
-    return this.include.filter((it) => {
-      return !this.exclude.includes(it);
+  static resolveParseFiles(config: ParseFilesConfig): string[] {
+    return config.include.filter((it) => {
+      return !config.exclude.includes(it);
     });
   }
 }


### PR DESCRIPTION
feat: Add ParseFilesConfig.resolveParseFiles to handle the include/exclude config, allow it's used outside the `cxx-parser` package.