### PR TITLE
[cxx-parser] Allow add prefix to the build directory name

### DIFF
--- a/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser_configs.test.ts
@@ -18,6 +18,19 @@ describe('CXXParserConfigs', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('resolve buildDirNamePrefix', () => {
+    let args = {
+      buildDirNamePrefix: 'prefix',
+    };
+
+    let config = CXXParserConfigs.resolve(
+      tmpDir,
+      args as unknown as CXXParserConfigs
+    );
+
+    expect(config.buildDirNamePrefix).toEqual('prefix');
+  });
+
   it('resolve parseFiles and keep path order', () => {
     let path1 = path.join(tmpDir, 'file1.h');
     let path2 = path.join(tmpDir, 'file2.h');

--- a/cxx-parser/src/cxx_parser.ts
+++ b/cxx-parser/src/cxx_parser.ts
@@ -23,9 +23,16 @@ export function generateChecksum(files: string[]) {
     .toString();
 }
 
-function getBuildDir(terraContext: TerraContext) {
+function getBuildDir(
+  terraContext: TerraContext,
+  buildDirNamePrefix?: string | undefined
+) {
+  let prefix = buildDirNamePrefix ?? '';
+  if (prefix.length) {
+    prefix = `${prefix}_`;
+  }
   // <my_project>/.terra/cxx_parser
-  return path.join(terraContext.buildDir, 'cxx_parser');
+  return path.join(terraContext.buildDir, `${prefix}cxx_parser`);
 }
 
 export function getCppAstBackendDir() {
@@ -36,11 +43,12 @@ export function dumpCXXAstJson(
   terraContext: TerraContext,
   includeHeaderDirs: string[],
   parseFiles: string[],
-  defines: string[]
+  defines: string[],
+  buildDirNamePrefix?: string | undefined
 ): string {
   let parseFilesChecksum = generateChecksum(parseFiles);
 
-  let buildDir = getBuildDir(terraContext);
+  let buildDir = getBuildDir(terraContext, buildDirNamePrefix);
   let preProcessParseFilesDir = path.join(
     buildDir,
     `preProcess@${parseFilesChecksum}`
@@ -124,7 +132,8 @@ export function CXXParser(
     terraContext,
     cxxParserConfigs.includeHeaderDirs,
     parseFiles,
-    cxxParserConfigs.definesMacros
+    cxxParserConfigs.definesMacros,
+    cxxParserConfigs.buildDirNamePrefix
   );
 
   let newParseResult = genParseResultFromJson(jsonContent);
@@ -136,7 +145,7 @@ export function CXXParser(
   });
 
   ClangASTStructConstructorParser(
-    getBuildDir(terraContext),
+    getBuildDir(terraContext, cxxParserConfigs.buildDirNamePrefix),
     cxxParserConfigs.includeHeaderDirs,
     cppastParsedFiles,
     newParseResult

--- a/cxx-parser/src/cxx_parser_configs.ts
+++ b/cxx-parser/src/cxx_parser_configs.ts
@@ -33,6 +33,7 @@ export class ParseFilesConfig {
 }
 
 export interface CXXParserConfigs {
+  buildDirNamePrefix?: string;
   includeHeaderDirs: string[];
   definesMacros: string[];
   parseFiles: ParseFilesConfig;
@@ -41,6 +42,7 @@ export interface CXXParserConfigs {
 export class CXXParserConfigs {
   static resolve(configDir: any, original: CXXParserConfigs): CXXParserConfigs {
     return {
+      buildDirNamePrefix: original.buildDirNamePrefix,
       includeHeaderDirs: (original.includeHeaderDirs ?? [])
         .map((it) => {
           return _resolvePaths(it, configDir);

--- a/cxx-parser/src/cxx_parser_configs.ts
+++ b/cxx-parser/src/cxx_parser_configs.ts
@@ -50,12 +50,12 @@ export class CXXParserConfigs {
         .flat(1),
       definesMacros: original.definesMacros ?? [],
       parseFiles: {
-        include: (original.parseFiles.include ?? [])
+        include: (original.parseFiles?.include ?? [])
           .map((it) => {
             return _resolvePaths(it, configDir);
           })
           .flat(1),
-        exclude: (original.parseFiles.exclude ?? [])
+        exclude: (original.parseFiles?.exclude ?? [])
           .map((it) => {
             return _resolvePaths(it, configDir);
           })


### PR DESCRIPTION
The build directory name of `cxx-parser` is `cxx_parser`, allowing adding a prefix to the build directory name to help isolate each run of the `cxx-parser`.