### PR TITLE
fix: Fix can not find the correct parent node with the same name

### DIFF
--- a/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
+++ b/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
@@ -65,6 +65,7 @@ describe('cxx_parser', () => {
                       "is_mutable":false,
                       "name":"a",
                       "namespaces": [],
+                      "parent_full_scope_name": "AAA",
                       "parent_name": "AAA",
                       "source": "",
                       "type":{
@@ -81,6 +82,7 @@ describe('cxx_parser', () => {
                   "methods":[],
                   "name":"AAA",
                   "namespaces":[],
+                  "parent_full_scope_name": "",
                   "parent_name":"${preProcessParseFilesDir}/file1.h",
                   "source":""
                 }
@@ -142,6 +144,7 @@ describe('cxx_parser', () => {
                     "is_mutable":false,
                     "name":"a",
                     "namespaces": [],
+                    "parent_full_scope_name": "AAA",
                     "parent_name": "AAA",
                     "source": "",
                     "type":{
@@ -158,6 +161,7 @@ describe('cxx_parser', () => {
                 "methods":[],
                 "name":"AAA",
                 "namespaces":[],
+                "parent_full_scope_name": "",
                 "parent_name":"${preProcessParseFilesDir}/file1.h",
                 "source":""
               }
@@ -223,6 +227,7 @@ describe('cxx_parser', () => {
                     "is_mutable":false,
                     "name":"a",
                     "namespaces": [],
+                    "parent_full_scope_name": "",
                     "parent_name": "",
                     "source": "",
                     "type":{
@@ -239,6 +244,7 @@ describe('cxx_parser', () => {
                 "methods":[],
                 "name":"AAA",
                 "namespaces":[],
+                "parent_full_scope_name": "",
                 "parent_name":"${preProcessParseFilesDir}/file1.h",
                 "source":""
               }
@@ -299,6 +305,7 @@ describe('cxx_parser', () => {
                     "file_path": "",
                     "name": "A",
                     "namespaces": [],
+                    "parent_full_scope_name": "MyEnum",
                     "parent_name": "MyEnum",
                     "source": "0",
                     "value": "0"
@@ -307,6 +314,7 @@ describe('cxx_parser', () => {
                 "file_path":"${preProcessParseFilesDir}/file1.h",
                 "name":"MyEnum",
                 "namespaces":[],
+                "parent_full_scope_name": "",
                 "parent_name":"${preProcessParseFilesDir}/file1.h",
                 "source":""
               }
@@ -375,6 +383,7 @@ describe('cxx_parser', () => {
                 "file_path":"${preProcessParseFilesDir}/file1.h",
                 "name":"MyEnum",
                 "namespaces":[],
+                "parent_full_scope_name": "",
                 "parent_name":"${preProcessParseFilesDir}/file1.h",
                 "source":""
               }
@@ -427,6 +436,7 @@ describe('cxx_parser', () => {
                 "file_path":"${preProcessParseFilesDir}/file1.h",
                 "name": "view_t",
                 "namespaces": [],
+                "parent_full_scope_name": "",
                 "parent_name":"${preProcessParseFilesDir}/file1.h",
                 "source": "",
                 "underlyingType": {
@@ -503,6 +513,7 @@ describe('cxx_parser', () => {
                     "is_mutable":false,
                     "name":"a",
                     "namespaces": [],
+                    "parent_full_scope_name": "AAA",
                     "parent_name": "AAA",
                     "source": "",
                     "type":{
@@ -519,6 +530,7 @@ describe('cxx_parser', () => {
                 "methods":[],
                 "name":"AAA",
                 "namespaces":[],
+                "parent_full_scope_name": "",
                 "parent_name":"${preProcessParseFilesDir}/file1.h",
                 "source":""
               },
@@ -530,6 +542,7 @@ describe('cxx_parser', () => {
                 "file_path":"${preProcessParseFilesDir}/file1.h",
                 "name": "view_t",
                 "namespaces": [],
+                "parent_full_scope_name": "",
                 "parent_name":"${preProcessParseFilesDir}/file1.h",
                 "source": "",
                 "underlyingType": {

--- a/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
+++ b/cxx-parser/__integration_test__/cxx_parser.integration.test.ts
@@ -375,6 +375,7 @@ describe('cxx_parser', () => {
                     "file_path": "",
                     "name": "A",
                     "namespaces": [],
+                    "parent_full_scope_name": "",
                     "parent_name": "",
                     "source": "0",
                     "value": "0"

--- a/cxx-parser/__tests__/unit_test/cxx_parser.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser.test.ts
@@ -381,6 +381,7 @@ describe('cxx_parser', () => {
             "methods": [],
             "name": "IRtmEventHandler",
             "namespaces": ["agora", "rtm"],
+            "parent_full_scope_name": "",
             "parent_name": "",
             "source": ""
           },
@@ -396,6 +397,7 @@ describe('cxx_parser', () => {
             "methods": [],
             "name": "PresenceEvent",
             "namespaces": ["agora", "rtm"],
+            "parent_full_scope_name": "agora::rtm::IRtmEventHandler",
             "parent_name": "IRtmEventHandler",
             "source": ""
           },
@@ -411,6 +413,7 @@ describe('cxx_parser', () => {
             "methods": [],
             "name": "IntervalInfo",
             "namespaces": ["agora", "rtm"],
+            "parent_full_scope_name": "agora::rtm::IRtmEventHandler::PresenceEvent",
             "parent_name": "PresenceEvent",
             "source": ""
           }
@@ -450,6 +453,7 @@ describe('cxx_parser', () => {
             "methods": [],
             "name": "IRtmEventHandler",
             "namespaces": ["agora", "rtm"],
+            "parent_full_scope_name": "",
             "parent_name": "",
             "source": ""
           },
@@ -465,6 +469,7 @@ describe('cxx_parser', () => {
             "methods": [],
             "name": "IRtmEventHandler",
             "namespaces": ["agora", "rtm", "base"],
+            "parent_full_scope_name": "",
             "parent_name": "",
             "source": ""
           },
@@ -480,6 +485,7 @@ describe('cxx_parser', () => {
             "methods": [],
             "name": "PresenceEvent",
             "namespaces": ["agora", "rtm"],
+            "parent_full_scope_name": "agora::rtm::IRtmEventHandler",
             "parent_name": "IRtmEventHandler",
             "source": ""
           },
@@ -495,6 +501,7 @@ describe('cxx_parser', () => {
             "methods": [],
             "name": "IntervalInfo",
             "namespaces": ["agora", "rtm"],
+            "parent_full_scope_name": "agora::rtm::IRtmEventHandler::PresenceEvent",
             "parent_name": "PresenceEvent",
             "source": ""
           }

--- a/cxx-parser/__tests__/unit_test/cxx_parser.test.ts
+++ b/cxx-parser/__tests__/unit_test/cxx_parser.test.ts
@@ -430,5 +430,89 @@ describe('cxx_parser', () => {
         'agora::rtm::IRtmEventHandler::PresenceEvent::IntervalInfo'
       );
     });
+
+    it('can fill parent node with a same parent name node', () => {
+      let json = `
+    [
+      {
+        "__TYPE": "CXXFile",
+        "file_path": "IAgoraRtmClient.h",
+        "nodes": [
+          {
+            "__TYPE": "Clazz",
+            "attributes": [],
+            "base_clazzs": [],
+            "comment": "",
+            "conditional_compilation_directives_infos": [],
+            "constructors": [],
+            "file_path": "IAgoraRtmClient.h",
+            "member_variables": [],
+            "methods": [],
+            "name": "IRtmEventHandler",
+            "namespaces": ["agora", "rtm"],
+            "parent_name": "",
+            "source": ""
+          },
+          {
+            "__TYPE": "Clazz",
+            "attributes": [],
+            "base_clazzs": [],
+            "comment": "",
+            "conditional_compilation_directives_infos": [],
+            "constructors": [],
+            "file_path": "IAgoraRtmClient.h",
+            "member_variables": [],
+            "methods": [],
+            "name": "IRtmEventHandler",
+            "namespaces": ["agora", "rtm", "base"],
+            "parent_name": "",
+            "source": ""
+          },
+          {
+            "__TYPE": "Struct",
+            "attributes": [],
+            "base_clazzs": [],
+            "comment": "",
+            "conditional_compilation_directives_infos": [],
+            "constructors": [],
+            "file_path": "IAgoraRtmClient.h",
+            "member_variables": [],
+            "methods": [],
+            "name": "PresenceEvent",
+            "namespaces": ["agora", "rtm"],
+            "parent_name": "IRtmEventHandler",
+            "source": ""
+          },
+          {
+            "__TYPE": "Struct",
+            "attributes": [],
+            "base_clazzs": [],
+            "comment": "",
+            "conditional_compilation_directives_infos": [],
+            "constructors": [],
+            "file_path": "IAgoraRtmClient.h",
+            "member_variables": [],
+            "methods": [],
+            "name": "IntervalInfo",
+            "namespaces": ["agora", "rtm"],
+            "parent_name": "PresenceEvent",
+            "source": ""
+          }
+        ]
+      }  
+    ]   
+`;
+
+      let parseResult = genParseResultFromJson(json);
+      let nestedStruct1 = (parseResult.nodes[0] as CXXFile).nodes[2] as Struct;
+      expect(nestedStruct1!.fullName).toEqual(
+        'agora::rtm::IRtmEventHandler::PresenceEvent'
+      );
+
+      let nestedStruct2 = (parseResult.nodes[0] as CXXFile).nodes[3] as Struct;
+      expect(nestedStruct2!.fullName).toEqual(
+        'agora::rtm::IRtmEventHandler::PresenceEvent::IntervalInfo'
+      );
+    });
   });
 });

--- a/cxx-parser/cxx/terra/include/terra.hpp
+++ b/cxx-parser/cxx/terra/include/terra.hpp
@@ -394,12 +394,15 @@ namespace terra
 
             std::cout << "enum: " << enumz.name << "\n";
 
+            std::vector<std::string> enumFullScopeList(parentFullScopeList);
+            enumFullScopeList.push_back(enumz.name);
+
             for (auto &en : cpp_enum)
             {
                 EnumConstant enum_constant;
                 enum_constant.name = en.name();
 
-                parse_base_node(enum_constant, {}, {}, "", en);
+                parse_base_node(enum_constant, {}, enumFullScopeList, "", en);
                 enum_constant.parent_name = cpp_enum.name();
                 if (en.value().has_value())
                 {
@@ -458,7 +461,6 @@ namespace terra
 
             for (auto &base : cpp_class.bases())
             {
-                // clazz->base_clazzs.push_back(std::string(base.name()));
                 base_clazzs.push_back(std::string(base.name()));
             }
 
@@ -482,7 +484,6 @@ namespace terra
 
                     Constructor constructor;
                     parse_constructor(constructor, namespaceList, classFullScopeList, file_path, cpp_constructor);
-                    // clazz->constructors.push_back(constructor);
                     constructors.push_back(constructor);
                     break;
                 }
@@ -494,7 +495,6 @@ namespace terra
                     parse_method(method, namespaceList, classFullScopeList, file_path, func, current_access_specifier);
                     method.attributes = std::vector<std::string>(parse_attributes(member));
 
-                    // clazz->methods.push_back(method);
                     methods.push_back(method);
                     break;
                 }
@@ -503,14 +503,11 @@ namespace terra
                     auto &cpp_member_variable = static_cast<const cppast::cpp_member_variable &>(member);
                     MemberVariable member_variable;
                     parse_member_variables(member_variable, namespaceList, classFullScopeList, file_path, cpp_member_variable, current_access_specifier);
-                    // clazz->member_variables.push_back(member_variable);
                     member_variables.push_back(member_variable);
                     break;
                 }
                 case cppast::cpp_entity_kind::class_t:
                 {
-                    std::cout << "child cpp_entity_kind::class_t: " << member.name() << " (" << cppast::to_string(member.kind()) << ")"
-                              << "\n";
                 }
 
                 default:

--- a/cxx-parser/cxx/terra/include/terra_node.hpp
+++ b/cxx-parser/cxx/terra/include/terra_node.hpp
@@ -38,6 +38,7 @@ namespace terra
         std::vector<std::string> namespaces;
         std::string file_path;
         std::string parent_name;
+        std::string parent_full_scope_name;
         std::vector<std::string> attributes;
         std::string comment;
         std::string source;

--- a/cxx-parser/src/cxx_parser.ts
+++ b/cxx-parser/src/cxx_parser.ts
@@ -204,8 +204,9 @@ function _findParent(
 function fillParentNode(parseResult: ParseResult, cxxFiles: CXXFile[]) {
   cxxFiles.forEach((file) => {
     file.nodes.forEach((node) => {
-      if (node.parent_name) {
-        node.parent = _findParent(parseResult, node.parent_name);
+      if (node.parent_full_scope_name) {
+        node.parent =
+          parseResult.resolveNodeByName(node.parent_full_scope_name) ?? file; // _findParent(parseResult, node.parent_name);
       } else {
         node.parent = file;
       }

--- a/cxx-parser/src/cxx_parser.ts
+++ b/cxx-parser/src/cxx_parser.ts
@@ -9,7 +9,7 @@ import { ParseResult, TerraContext } from '@agoraio-extensions/terra-core';
 
 import { ClangASTStructConstructorParser } from './constructor_initializer_parser';
 import { CXXParserConfigs, ParseFilesConfig } from './cxx_parser_configs';
-import { CXXFile, CXXTYPE, cast } from './cxx_terra_node';
+import { CXXFile, CXXTYPE, CXXTerraNode, cast } from './cxx_terra_node';
 
 export function generateChecksum(files: string[]) {
   let allFileContents = files
@@ -157,11 +157,55 @@ export function CXXParser(
   return newParseResult;
 }
 
+/// Workaround for finding the parent nodes with the same name, this only works if the namespaces are different.
+/// To excectly find the parent node, we need to add more infos in `CXXTerraNode` to identity the unique parent node.
+function _findParent(
+  parseResult: ParseResult,
+  parentName: string
+): CXXTerraNode | undefined {
+  function _findResolvedNodeRecursively(
+    node: CXXTerraNode
+  ): CXXTerraNode | undefined {
+    let tmpFullName = node.parent_name
+      ? `${node.parent_name}::${node.name}`
+      : `${node.namespaces.join('::')}::${node.name}`;
+    let tmpNode = parseResult.resolveNodeByName(tmpFullName);
+    if (tmpNode && tmpNode.parent_name) {
+      // recursively find the parent node
+      tmpNode = _findResolvedNodeRecursively(tmpNode);
+    }
+    return tmpNode;
+  }
+  let foundNode: CXXTerraNode | undefined;
+
+  for (const f of parseResult.nodes) {
+    let cxxFile = f as CXXFile;
+    let foundNodes = cxxFile.nodes.filter((node) => node.name == parentName);
+    if (foundNodes.length == 0) {
+      continue;
+    }
+
+    if (foundNodes.length == 1) {
+      return foundNodes[0];
+    }
+
+    for (let node of foundNodes) {
+      // find the most matched node
+      foundNode = _findResolvedNodeRecursively(node);
+      if (foundNode) {
+        return foundNode;
+      }
+    }
+  }
+
+  return foundNode;
+}
+
 function fillParentNode(parseResult: ParseResult, cxxFiles: CXXFile[]) {
   cxxFiles.forEach((file) => {
     file.nodes.forEach((node) => {
       if (node.parent_name) {
-        node.parent = parseResult.resolveNodeByName(node.parent_name) ?? file;
+        node.parent = _findParent(parseResult, node.parent_name);
       } else {
         node.parent = file;
       }

--- a/cxx-parser/src/cxx_terra_node.ts
+++ b/cxx-parser/src/cxx_terra_node.ts
@@ -41,6 +41,7 @@ export abstract class CXXTerraNode implements TerraNode {
   file_path: string = '';
   namespaces: string[] = [];
   parent_name: string = '';
+  parent_full_scope_name: string = '';
   parent?: CXXTerraNode;
 
   attributes: string[] = [];


### PR DESCRIPTION
e.g., the `parent_name` of `C` is `B`, we can not find the correct parent node for `C`
```
A::B::C
D::B::C
```
Add a new property(`parent_full_scope_name `) with the full parent scope to fix this issue.

Another fix for https://github.com/AgoraIO-Extensions/terra/pull/52